### PR TITLE
Fix: Updated Python logo placeholders for RedBlackTree & BellmanFord

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ In order to achieve greater coverage and encourage more people to contribute to 
             </td>
             <td> <!-- Python -->
                 <a href="./CONTRIBUTING.md">
-                    <img align="center" height="25" src="./logos/python.svg" />
+                    <img align="center" height="25" src="./logos/github.svg" />
                 </a>
             </td>
             <td> <!-- Go -->
@@ -2753,7 +2753,7 @@ In order to achieve greater coverage and encourage more people to contribute to 
             </td>
             <td> <!-- Python -->
                 <a href="./CONTRIBUTING.md">
-                    <img align="center" height="25" src="./logos/python.svg" />
+                    <img align="center" height="25" src="./logos/github.svg" />
                 </a>
             </td>
             <td> <!-- Go -->


### PR DESCRIPTION
Red-Black Tree and Bellman-Ford algorithms python placeholder logos changed to the correct GitHub logo. All logos are now consistent across the new additions.
